### PR TITLE
add comment on installing prerequisite libraries scratchpy and pyusb

### DIFF
--- a/retaliscratch.py
+++ b/retaliscratch.py
@@ -29,6 +29,8 @@
 # Retaliscratch - operate missile launcher from Scratch
 # http://scratch.mit.edu
 #
+# Install prerequisites: pip install scratchpy pyusb
+#
 # To use:
 # 1) Start Scratch, enable Remote Sensor Connections.
 #    See: http://wiki.scratch.mit.edu/wiki/Remote_Sensor_Connections


### PR DESCRIPTION
Beginners will find a brief note helpful explaining that the scratchpy and pyusb packages are prerequisites for using this library, and how to install them with pip.
